### PR TITLE
fix: variant is optional for stories

### DIFF
--- a/src/fetchStoryHtml.ts
+++ b/src/fetchStoryHtml.ts
@@ -21,15 +21,22 @@ const fetchStoryHtml = async (
   // Remove trailing slash.
   url = url.replace(/\/$/, '');
 
-  const variant = context.parameters.options.variant;
+  const variant = context.parameters?.options?.variant;
 
   const fetchUrl = new URL(`${url}/_cl_server`);
-  fetchUrl.search = new URLSearchParams({
+  const init: {
+    _storyFileName: string;
+    _drupalTheme: string;
+    _variant?: string;
+  } = {
     ...params,
     _storyFileName: context.parameters.fileName,
     _drupalTheme: context.globals.drupalTheme || context.parameters.drupalTheme,
-    _variant: variant,
-  }).toString();
+  };
+  if (variant) {
+    init._variant = variant;
+  }
+  fetchUrl.search = new URLSearchParams(init).toString();
 
   // Remove any basic auth embedded into the URL and remove it as it will cause
   // the OPTIONS pre-flight request to fail.


### PR DESCRIPTION
Component variants are optional for the stories and components. However the Storyboon integration fails if none is provided.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.10-canary.6.414b7c2.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @lullabot/storybook-drupal-addon@1.0.10-canary.6.414b7c2.0
  # or 
  yarn add @lullabot/storybook-drupal-addon@1.0.10-canary.6.414b7c2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
