### PR TITLE
fix: use window object directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ storybook-static/
 build-storybook.log
 .DS_Store
 .env
+yarn-error.log

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -1,4 +1,4 @@
-import * as global from 'global';
+const globalWindow = require('global/window');
 import {
   StoryContext,
   StoryFn as StoryFunction,
@@ -7,8 +7,6 @@ import {
   useGlobals,
   useState,
 } from '@storybook/addons';
-
-const { window: globalWindow } = global;
 
 export const withDrupalTheme = (
   StoryFn: StoryFunction,


### PR DESCRIPTION
Otherwise the browser may throw an error.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.19-canary.14.8697e0f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @lullabot/storybook-drupal-addon@1.0.19-canary.14.8697e0f.0
  # or 
  yarn add @lullabot/storybook-drupal-addon@1.0.19-canary.14.8697e0f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
