### PR TITLE
fix: use window directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,6 @@
   },
   "bugs": {
     "url": "https://github.com/Lullabot/storybook-drupal-addon/issues"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Panel = ({ active }: { active: boolean }) => {
+  return active ? <p>Drupal Panel</p> : <></>;
+};

--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -9,7 +9,7 @@ addons.register(ADDON_ID, () => {
   addons.add(TOOL_ID, {
     type: types.TOOL,
     title: 'Drupal Theme',
-    match: ({viewMode}) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
+    match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
     render: Tool,
   });
 });

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -1,4 +1,3 @@
-const globalWindow = require('global/window');
 import {
   StoryContext,
   StoryFn as StoryFunction,
@@ -15,7 +14,7 @@ export const withDrupalTheme = (
   const [globals, updateGlobals] = useGlobals();
   const [hash, setHash] = useState<string>('');
   const refresh = useCallback(() => {
-    globalWindow.document.location.reload();
+    window.document.location.reload();
   }, []);
   if (globals?.drupalTheme) {
     console.log(
@@ -38,7 +37,8 @@ export const withDrupalTheme = (
 
   useEffect(() => {
     const sourceWrapper =
-      globalWindow?.__whmEventSourceWrapper['/__webpack_hmr'];
+      // @ts-ignore
+      window?.__whmEventSourceWrapper['/__webpack_hmr'];
     if (!sourceWrapper) {
       return;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4055,9 +4055,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001219:
-  version "1.0.30001234"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001234.tgz#8fc2e709e3b0679d7af7f073a1c661155c39b975"
-  integrity sha512-a3gjUVKkmwLdNysa1xkUAwN2VfJUJyVW47rsi3aCbkRCtbHAfo+rOsCqVw29G6coQ8gzAPb5XBXwiGHwme3isA==
+  version "1.0.30001363"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz"
+  integrity sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.20-canary.15.df5d0f3.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @lullabot/storybook-drupal-addon@1.0.20-canary.15.df5d0f3.0
  # or 
  yarn add @lullabot/storybook-drupal-addon@1.0.20-canary.15.df5d0f3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
