### PR TITLE
perf: avoid unnecessary re-renders

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -2,15 +2,16 @@ import React, { ReactElement } from 'react';
 import { useGlobals } from '@storybook/api';
 import {
   IconButton,
-  Link as LinkStorybook,
   TooltipLinkList,
   WithTooltip,
 } from '@storybook/components';
 import { TOOL_ID } from './constants';
 
-export interface Link extends LinkStorybook {
+export interface Link {
+  id: string;
   active: boolean;
   title: string;
+  onClick: () => void
 }
 
 type ExpandedThemeValue = { title: string };

--- a/src/fetchStoryHtml.ts
+++ b/src/fetchStoryHtml.ts
@@ -25,7 +25,9 @@ function createNewBody(htmlDoc: Document): HTMLElement {
   newBody.innerHTML = clWrapper.innerHTML;
   // Include the Drupal "js footer" assets, i.e., all the <script> tags in
   // the <body>.
-  newBody.append(...Array.from(scripts));
+  const footerScripts = htmlDoc.createElement('div');
+  footerScripts.append(...Array.from(scripts));
+  newBody.append(footerScripts);
   return newBody;
 }
 

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -2,15 +2,31 @@ const globalWindow = require('global/window');
 import {
   StoryContext,
   StoryFn as StoryFunction,
+  useCallback,
   useEffect,
   useGlobals,
+  useState,
 } from '@storybook/addons';
+
+const defaultDebounceTimeout = 300;
+const heartBeatEmoji = '\uD83D\uDC93';
 
 export const withDrupalTheme = (
   StoryFn: StoryFunction,
   context: StoryContext,
 ) => {
   const [globals, updateGlobals] = useGlobals();
+  const refresh = useCallback(() => {
+    const delay = globals?.debounceTimeout || defaultDebounceTimeout;
+    const isLocked = globals?.debounceTimeout || false;
+    if (!isLocked) {
+      // Lock the refresh procedure.
+      updateGlobals({isLocked: true})
+      globalWindow.document.location.reload();
+      // Unlock it again soon.
+      setTimeout(() => updateGlobals({isLocked: false}), delay);
+    }
+  }, [globals]);
   useEffect(() => {
     const {
       parameters: {drupalTheme, supportedDrupalThemes},
@@ -21,6 +37,38 @@ export const withDrupalTheme = (
       } else {
         updateGlobals({supportedDrupalThemes});
       }
+    }
+  }, [globals]);
+
+  useEffect(() => {
+    const hmr = globalWindow?.__whmEventSourceWrapper?.['/__webpack_hmr'];
+    if (!hmr) {
+      return;
+    }
+    hmr.addMessageListener(handleMessage);
+
+    function handleMessage(event: MessageEvent) {
+      if (event.data == heartBeatEmoji) {
+        return;
+      }
+      let data;
+      try {
+        data = JSON.parse(event.data);
+      } catch (ex) {
+        console.warn('Invalid HMR message: ' + event.data + '\n' + ex);
+        return;
+      }
+      const currentHash = globals?.hash;
+      const newHash = data?.hash;
+      if (!newHash) {
+        return;
+      }
+      currentHash === newHash
+        // If nothing changed in the Webpack hash, it may mean changes in the
+        // server components.
+        ? refresh()
+        // Store the hash in the globals because state will reset every time.
+        : updateGlobals({hash: newHash});
     }
   }, [globals]);
 

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -69,7 +69,7 @@ export const withDrupalTheme = (
         refresh();
       }
     }
-  }, [globals]);
+  }, [hash, setHash]);
 
   return StoryFn(undefined, undefined);
 };

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -47,7 +47,29 @@ export const withDrupalTheme = (
     }
     hmr.addMessageListener(handleMessage);
 
-    function handleMessage(event: MessageEvent) {}
+    function handleMessage(event: MessageEvent) {
+      if (event.data == heartBeatEmoji) {
+        return;
+      }
+      let data;
+      try {
+        data = JSON.parse(event.data);
+      } catch (ex) {
+        console.warn('Invalid HMR message: ' + event.data + '\n' + ex);
+        return;
+      }
+      const currentHash = globals?.hash;
+      const newHash = data?.hash;
+      if (!newHash) {
+        return;
+      }
+      currentHash === newHash
+        // If nothing changed in the Webpack hash, it may mean changes in the
+        // server components.
+        ? refresh()
+        // Store the hash in the globals because state will reset every time.
+        : updateGlobals({hash: newHash});
+    }
   }, [globals]);
 
   return StoryFn(undefined, undefined);

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -22,7 +22,7 @@ export const withDrupalTheme = (
     if (!isLocked) {
       // Lock the refresh procedure.
       updateGlobals({isLocked: true})
-      globalWindow.document.location.reload();
+      // globalWindow.document.location.reload();
       // Unlock it again soon.
       setTimeout(() => updateGlobals({isLocked: false}), delay);
     }

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -8,7 +8,8 @@ import {
   useState,
 } from '@storybook/addons';
 
-const  defaultDebounceTimeout = 300;
+const defaultDebounceTimeout = 300;
+const heartBeatEmoji = '\uD83D\uDC93';
 
 export const withDrupalTheme = (
   StoryFn: StoryFunction,
@@ -29,13 +30,13 @@ export const withDrupalTheme = (
   }, [isLocked, setLock, delay]);
   useEffect(() => {
     const {
-      parameters: { drupalTheme, supportedDrupalThemes },
+      parameters: {drupalTheme, supportedDrupalThemes},
     } = context;
     if (supportedDrupalThemes && !globals?.supportedDrupalThemes) {
       if (drupalTheme && !globals?.drupalTheme) {
-        updateGlobals({ drupalTheme, supportedDrupalThemes });
+        updateGlobals({drupalTheme, supportedDrupalThemes});
       } else {
-        updateGlobals({ supportedDrupalThemes });
+        updateGlobals({supportedDrupalThemes});
       }
     }
   }, [globals]);
@@ -48,7 +49,7 @@ export const withDrupalTheme = (
     hmr.addMessageListener(handleMessage);
 
     function handleMessage(event: MessageEvent) {
-      if (event.data == '\uD83D\uDC93') {
+      if (event.data == heartBeatEmoji) {
         return;
       }
       let data;
@@ -58,16 +59,15 @@ export const withDrupalTheme = (
         console.warn('Invalid HMR message: ' + event.data + '\n' + ex);
         return;
       }
-      if (!data?.hash) {
+      const newHash = data?.hash;
+      if (!newHash) {
         return;
       }
-      if (hash.length === 0 || hash !== data?.hash) {
-        setHash(data?.hash);
-      } else {
+      hash.length !== 0 && hash === newHash
         // If nothing changed in the Webpack hash, it may mean changes in the
         // server components.
-        refresh();
-      }
+        ? refresh()
+        : setHash(hash);
     }
   }, [hash, setHash]);
 

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -67,7 +67,7 @@ export const withDrupalTheme = (
         // If nothing changed in the Webpack hash, it may mean changes in the
         // server components.
         ? refresh()
-        : setHash(hash);
+        : setHash(newHash);
     }
   }, [hash, setHash]);
 

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -8,21 +8,25 @@ import {
   useState,
 } from '@storybook/addons';
 
+const  defaultDebounceTimeout = 300;
+
 export const withDrupalTheme = (
   StoryFn: StoryFunction,
   context: StoryContext,
 ) => {
   const [globals, updateGlobals] = useGlobals();
   const [hash, setHash] = useState<string>('');
+  const [isLocked, setLock] = useState<boolean>(false);
+  const delay = globals?.debounceTimeout || defaultDebounceTimeout;
   const refresh = useCallback(() => {
-    globalWindow.document.location.reload();
-  }, []);
-  if (globals?.drupalTheme) {
-    console.log(
-      `Rendering component using Drupal theme: ${globals?.drupalTheme}`,
-    );
-  }
-
+    if (!isLocked) {
+      // Lock the refresh procedure.
+      setLock(true);
+      globalWindow.document.location.reload();
+      // Unlock it again soon.
+      setTimeout(() => setLock(false), delay);
+    }
+  }, [isLocked, setLock, delay]);
   useEffect(() => {
     const {
       parameters: { drupalTheme, supportedDrupalThemes },

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -2,31 +2,15 @@ const globalWindow = require('global/window');
 import {
   StoryContext,
   StoryFn as StoryFunction,
-  useCallback,
   useEffect,
   useGlobals,
-  useState,
 } from '@storybook/addons';
-
-const defaultDebounceTimeout = 300;
-const heartBeatEmoji = '\uD83D\uDC93';
 
 export const withDrupalTheme = (
   StoryFn: StoryFunction,
   context: StoryContext,
 ) => {
   const [globals, updateGlobals] = useGlobals();
-  const refresh = useCallback(() => {
-    const delay = globals?.debounceTimeout || defaultDebounceTimeout;
-    const isLocked = globals?.debounceTimeout || false;
-    if (!isLocked) {
-      // Lock the refresh procedure.
-      updateGlobals({isLocked: true})
-      globalWindow.document.location.reload();
-      // Unlock it again soon.
-      setTimeout(() => updateGlobals({isLocked: false}), delay);
-    }
-  }, [globals]);
   useEffect(() => {
     const {
       parameters: {drupalTheme, supportedDrupalThemes},
@@ -37,38 +21,6 @@ export const withDrupalTheme = (
       } else {
         updateGlobals({supportedDrupalThemes});
       }
-    }
-  }, [globals]);
-
-  useEffect(() => {
-    const hmr = globalWindow?.__whmEventSourceWrapper?.['/__webpack_hmr'];
-    if (!hmr) {
-      return;
-    }
-    hmr.addMessageListener(handleMessage);
-
-    function handleMessage(event: MessageEvent) {
-      if (event.data == heartBeatEmoji) {
-        return;
-      }
-      let data;
-      try {
-        data = JSON.parse(event.data);
-      } catch (ex) {
-        console.warn('Invalid HMR message: ' + event.data + '\n' + ex);
-        return;
-      }
-      const currentHash = globals?.hash;
-      const newHash = data?.hash;
-      if (!newHash) {
-        return;
-      }
-      currentHash === newHash
-        // If nothing changed in the Webpack hash, it may mean changes in the
-        // server components.
-        ? refresh()
-        // Store the hash in the globals because state will reset every time.
-        : updateGlobals({hash: newHash});
     }
   }, [globals]);
 

--- a/src/withDrupalTheme.ts
+++ b/src/withDrupalTheme.ts
@@ -47,29 +47,7 @@ export const withDrupalTheme = (
     }
     hmr.addMessageListener(handleMessage);
 
-    function handleMessage(event: MessageEvent) {
-      if (event.data == heartBeatEmoji) {
-        return;
-      }
-      let data;
-      try {
-        data = JSON.parse(event.data);
-      } catch (ex) {
-        console.warn('Invalid HMR message: ' + event.data + '\n' + ex);
-        return;
-      }
-      const currentHash = globals?.hash;
-      const newHash = data?.hash;
-      if (!newHash) {
-        return;
-      }
-      currentHash === newHash
-        // If nothing changed in the Webpack hash, it may mean changes in the
-        // server components.
-        ? refresh()
-        // Store the hash in the globals because state will reset every time.
-        : updateGlobals({hash: newHash});
-    }
+    function handleMessage(event: MessageEvent) {}
   }, [globals]);
 
   return StoryFn(undefined, undefined);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.23--canary.22.18cfa06.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @lullabot/storybook-drupal-addon@1.0.23--canary.22.18cfa06.0
  # or 
  yarn add @lullabot/storybook-drupal-addon@1.0.23--canary.22.18cfa06.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
