### PR TITLE
fix: allow components to have nested props

### DIFF
--- a/src/fetchStoryHtml.ts
+++ b/src/fetchStoryHtml.ts
@@ -2,6 +2,7 @@ type StorybookContext = {
   globals: {
     drupalTheme?: string;
   };
+  args: Record<string, unknown>,
   parameters: {
     options: {
       variant: string;
@@ -51,7 +52,7 @@ const fetchStoryHtml = async (
   } = {
     _storyFileName: context.parameters.fileName,
     _drupalTheme: context.globals.drupalTheme || context.parameters.drupalTheme,
-    _params: btoa(unescape(encodeURIComponent(JSON.stringify(params)))),
+    _params: btoa(unescape(encodeURIComponent(JSON.stringify(context.args)))),
   };
   if (variant) {
     init._variant = variant;


### PR DESCRIPTION
Fixes #20
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.24--canary.23.9585579.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @lullabot/storybook-drupal-addon@1.0.24--canary.23.9585579.0
  # or 
  yarn add @lullabot/storybook-drupal-addon@1.0.24--canary.23.9585579.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
