### PR TITLE
fix: loading storybook/drupal-addon twice

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -2,11 +2,6 @@ function config(entry = []) {
   return [...entry, require.resolve('./dist/esm/preset/preview')];
 }
 
-function managerEntries(entry = []) {
-  return [...entry, require.resolve('./dist/esm/preset/manager')];
-}
-
 module.exports = {
-  managerEntries,
   config,
 };


### PR DESCRIPTION
When loading, in the browser console you get:

> storybook/drupal-addon was loaded twice, this could have bad side-effects

After tracing through webpack, we can see the last two lines:

```
    __webpack_exec__("./node_modules/@storybook/core-client/dist/esm/manager/index.js"),
    __webpack_exec__("./node_modules/@storybook/addon-links/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-docs/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-controls/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-actions/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-backgrounds/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-viewport/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-toolbars/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-measure/manager.js"),
    __webpack_exec__("./node_modules/@storybook/addon-outline/manager.js"),
    __webpack_exec__("./node_modules/@lullabot/storybook-drupal-addon/dist/esm/preset/manager.js"),
    __webpack_exec__("./node_modules/@lullabot/storybook-drupal-addon/manager.js")));
```

In contrast, there's no includes for the previous addons even though they have similar imports and requires.

It looks like we don't need to add our manager by hand at all. Removing this function fixes the error. While it doesn't cause any negative effects that I can tell, it also doesn't fix any of the other issues I'm currently debugging. Still, a warning like this seems like it could easily send those debugging issues down the wrong path.