### PR TITLE
Rename _storyFileName to _componentFileName

### DIFF
--- a/src/fetchStoryHtml.ts
+++ b/src/fetchStoryHtml.ts
@@ -45,12 +45,12 @@ const fetchStoryHtml = async (
 
   const fetchUrl = new URL(`${url}/_cl_server`);
   const init: {
-    _storyFileName: string;
+    _componentFileName: string;
     _drupalTheme: string;
     _variant?: string;
     _params: string;
   } = {
-    _storyFileName: context.parameters.fileName,
+    _componentFileName: context.parameters.fileName,
     _drupalTheme: context.globals.drupalTheme || context.parameters.drupalTheme,
     _params: btoa(unescape(encodeURIComponent(JSON.stringify(context.args)))),
   };


### PR DESCRIPTION
## Description

This PR updates the `fetchStoryHtml.ts` to rename the `_storyFileName` request parameter to `_componentFileName` in accordance with merge request [19](https://git.drupalcode.org/project/cl_server/-/merge_requests/19) in `cl_server`.

## Motivation

See Drupal issue [3387642](https://www.drupal.org/project/cl_server/issues/3387642).